### PR TITLE
feat: add stat slot

### DIFF
--- a/src/CodeDiff.vue
+++ b/src/CodeDiff.vue
@@ -88,8 +88,10 @@ watch(() => props, () => {
       <div class="file-info">
         <span class="filename">{{ filename }}</span>
         <span v-if="!hideStat" class="diff-stat">
-          <span class="diff-stat-added">+{{ diffChange.stat.additionsNum }} additions</span>
-          <span class="diff-stat-deleted" style="margin-left: 8px;">-{{ diffChange.stat.deletionsNum }} deletions</span>
+          <slot name="stat">
+            <span class="diff-stat-added">+{{ diffChange.stat.additionsNum }} additions</span>
+            <span class="diff-stat-deleted" style="margin-left: 8px;">-{{ diffChange.stat.deletionsNum }} deletions</span>
+          </slot>
         </span>
       </div>
     </div>


### PR DESCRIPTION
<img width="1646" alt="image" src="https://github.com/Shimada666/v-code-diff/assets/43346380/e42b4e53-1f57-4f59-a567-7577ae0db728">

为了方便用户自定义统计信息区域，提供了一个slot(stat)。
https://github.com/Shimada666/v-code-diff/issues/100