### PR TITLE
增加支持 ignoreMatchingLines 属性

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -124,7 +124,7 @@ Vue.use(CodeDiff)
 | hideHeader | 隐藏头部栏 | boolean | - | false |
 | hideStat | 隐藏头部栏中的统计信息 | boolean | - | false |
 | theme          | 用于切换日间模式/夜间模式                                                                                                               | ThemeType | light , dark               | light      |
-| ignoreMatchingLines | 给出一个模式来忽略匹配行，例如：'(time\|token)'（**仅支持 side-by-side**） | string | - |  |
+| ignoreMatchingLines | 给出一个模式来忽略匹配行，例如：'(time\|token)' | string | - |  |
 
 ## 组件事件
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -121,13 +121,22 @@ Vue.use(CodeDiff)
 | maxHeight      | 组件最大高度，例如 300px                                                                                                                | string    | -                          | undefined    |
 | filename       | 文件名                                                                                                                                  | string    | -                          | undefined    |
 | newFilename    | 新文件文件名                                                                                                                   | string    | -                          | undefined    |
+| hideHeader | 隐藏头部栏 | boolean | - | false |
+| hideStat | 隐藏头部栏中的统计信息 | boolean | - | false |
 | theme          | 用于切换日间模式/夜间模式                                                                                                               | ThemeType | light , dark               | light      |
+| ignoreMatchingLines | 给出一个模式来忽略匹配行，例如：'(time\|token)'（**仅支持 side-by-side**） | string | - |  |
 
 ## 组件事件
 
 | Name | Description     | Type                                                                            |
 | ---- | --------------- | ------------------------------------------------------------------------------- |
 | diff | diff 完成后触发 | (result: {stat: { isChanged: boolean, addNum: number, delNum: number}}) => void |
+
+## 组件插槽
+
+| Name | Description                     |
+| ---- | ------------------------------- |
+| stat | 自定义统计内容，参数为 { stat } |
 
 ## 拓展高亮语言
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Not recommended, but the relevant capabilities are retained to facilitate migrat
 | hideHeader | Hide header bar | boolean | - | false |
 | hideStat | Hide statistical part in the header bar | boolean | - | false |
 | theme          | Add dark mode                                                                                                                                                           | ThemeType | light , dark               | light       |
-| ignoreMatchingLines | Give a pattern to ignore matching lines eg: '(time\|token)' (**Only support side-by-side**) | string | - | undefined |
+| ignoreMatchingLines | Give a pattern to ignore matching lines eg: '(time\|token)' | string | - | undefined |
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,22 @@ Not recommended, but the relevant capabilities are retained to facilitate migrat
 | maxHeight      | Maximum height of component, for example: 300px                                                                                                                         | string    | -                          | undefined     |
 | filename       | Filename                                                                                                                                                                | string    | -                          | undefined     |
 | newFilename    | New filename                                                                                                                                                            | string    | -                          | undefined     |
+| hideHeader | Hide header bar | boolean | - | false |
+| hideStat | Hide statistical part in the header bar | boolean | - | false |
 | theme          | Add dark mode                                                                                                                                                           | ThemeType | light , dark               | light       |
+| ignoreMatchingLines | Give a pattern to ignore matching lines eg: '(time\|token)' (**Only support side-by-side**) | string | - | undefined |
 
 ## Events
 
 | Name | Description                 | Type                                                                            |
 | ---- | --------------------------- | ------------------------------------------------------------------------------- |
 | diff | triggers when diff finished | (result: {stat: { isChanged: boolean, addNum: number, delNum: number}}) => void |
+
+## Slot
+
+| Name | Description                                                 |
+| ---- | ----------------------------------------------------------- |
+| stat | Custom statistical content, The scope parameter is { stat } |
 
 ## Extend languages
 

--- a/src/CodeDiff.vue
+++ b/src/CodeDiff.vue
@@ -21,6 +21,8 @@ interface Props {
   hideHeader?: boolean
   hideStat?: boolean
   theme?: 'light' | 'dark'
+  // Give a pattern to ignore matching lines eg: '(time|token)' (**Only support side-by-side**)
+  ignoreMatchingLines?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -36,6 +38,7 @@ const props = withDefaults(defineProps<Props>(), {
   hideHeader: false,
   hideStat: false,
   theme: 'light',
+  ignoreMatchingLines: undefined,
 })
 
 const emits = defineEmits<{
@@ -68,7 +71,7 @@ const newString = computed(() => {
 const raw = computed(() =>
   isUnifiedViewer.value
     ? createUnifiedDiff(oldString.value, newString.value, props.language, props.diffStyle, props.context)
-    : createSplitDiff(oldString.value, newString.value, props.language, props.diffStyle, props.context),
+    : createSplitDiff(oldString.value, newString.value, props.language, props.diffStyle, props.context, props.ignoreMatchingLines),
 )
 const diffChange = ref(raw.value)
 const isNotChanged = computed(() => diffChange.value.stat.additionsNum === 0 && diffChange.value.stat.deletionsNum === 0)
@@ -110,6 +113,10 @@ watch(() => props, () => {
             <slot name="stat" :stat="diffChange.stat">
               <span class="diff-stat-added">+{{ diffChange.stat.additionsNum }} additions</span>
               <span class="diff-stat-deleted">-{{ diffChange.stat.deletionsNum }} deletions</span>
+              <span
+                v-if="diffChange.stat.ignoreNum.additions + diffChange.stat.ignoreNum.deletions > 0"
+                class="diff-stat-ignored"
+              >±{{ diffChange.stat.ignoreNum.additions + diffChange.stat.ignoreNum.deletions }} lines</span>
             </slot>
           </span>
         </span>

--- a/src/CodeDiff.vue
+++ b/src/CodeDiff.vue
@@ -113,10 +113,6 @@ watch(() => props, () => {
             <slot name="stat" :stat="diffChange.stat">
               <span class="diff-stat-added">+{{ diffChange.stat.additionsNum }} additions</span>
               <span class="diff-stat-deleted">-{{ diffChange.stat.deletionsNum }} deletions</span>
-              <span
-                v-if="diffChange.stat.ignoreNum.additions + diffChange.stat.ignoreNum.deletions > 0"
-                class="diff-stat-ignored"
-              >±{{ diffChange.stat.ignoreNum.additions + diffChange.stat.ignoreNum.deletions }} lines</span>
             </slot>
           </span>
         </span>

--- a/src/CodeDiff.vue
+++ b/src/CodeDiff.vue
@@ -21,7 +21,7 @@ interface Props {
   hideHeader?: boolean
   hideStat?: boolean
   theme?: 'light' | 'dark'
-  // Give a pattern to ignore matching lines eg: '(time|token)' (**Only support side-by-side**)
+  // Give a pattern to ignore matching lines eg: '(time|token)'
   ignoreMatchingLines?: string
 }
 
@@ -70,7 +70,7 @@ const newString = computed(() => {
 
 const raw = computed(() =>
   isUnifiedViewer.value
-    ? createUnifiedDiff(oldString.value, newString.value, props.language, props.diffStyle, props.context)
+    ? createUnifiedDiff(oldString.value, newString.value, props.language, props.diffStyle, props.context, props.ignoreMatchingLines)
     : createSplitDiff(oldString.value, newString.value, props.language, props.diffStyle, props.context, props.ignoreMatchingLines),
 )
 const diffChange = ref(raw.value)

--- a/src/style.scss
+++ b/src/style.scss
@@ -38,12 +38,17 @@
         width: 50%;
       }
       .diff-stat {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
         .diff-stat-added {
           color: var(--color-diffstat-addition-bg);
         }
         .diff-stat-deleted {
-          margin-left: 8px;
           color: var(--color-danger-emphasis);
+        }
+        .diff-stat-ignored {
+          color: var(--color-fg-subtle);
         }
       }
     }

--- a/src/style.scss
+++ b/src/style.scss
@@ -29,12 +29,12 @@
       height: 24px;
 
       .info-left {
-        font-size: 13px;
         color: var(--color-fg-default);
       }
       .info-right {
         display: flex;
         justify-content: space-between;
+        align-items: center;
         width: 50%;
       }
       .diff-stat {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface UnifiedLineChange {
 export interface DiffStat {
   additionsNum: number
   deletionsNum: number
+  ignoreNum: object
 }
 
 export interface SplitViewerChange {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,8 @@ export interface UnifiedLineChange {
 export interface DiffStat {
   additionsNum: number
   deletionsNum: number
-  ignoreNum: object
+  ignoreAdditionsNum: number
+  ignoreDeletionsNum: number
 }
 
 export interface SplitViewerChange {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -273,9 +273,10 @@ export function createSplitDiff(
 
           const leftLine = curLines.length === nextLines.length ? renderWords(nextLine, curLine, diffStyle) : curLine
           const rightLine = curLines.length === nextLines.length ? renderWords(curLine, nextLine, diffStyle) : nextLine
+
           // 忽略匹配的行等价于相等
-          const leftDiffType = ignoreRegex?.test(leftLine) ? DiffType.EQUAL : DiffType.DELETE
-          const rightDiffType = ignoreRegex?.test(rightLine) ? DiffType.EQUAL : DiffType.ADD
+          const leftDiffType = ignoreRegex?.test(curLine) ? DiffType.EQUAL : DiffType.DELETE
+          const rightDiffType = ignoreRegex?.test(nextLine) ? DiffType.EQUAL : DiffType.ADD
 
           const left
             = j < cur.count!

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,22 +141,28 @@ function calcDiffStat(changes: Change[], ignoreRegex?: RegExp): DiffStat {
 
   let additionsNum = 0
   let deletionsNum = 0
-  const ignoreNum = { additions: 0, deletions: 0 }
+  let ignoreAdditionsNum = 0
+  let ignoreDeletionsNum = 0
   for (const change of changes) {
     if (change.added) {
-      const ignoreLines = ignoreCount(change.value.trim().split('\n'))
-      additionsNum += count(change.value.trim(), '\n') + 1 - ignoreLines
-      ignoreNum.additions += ignoreLines
+      const ignoreNum = ignoreCount(change.value.trim().split('\n'))
+      additionsNum += count(change.value.trim(), '\n') + 1 - ignoreNum
+      ignoreAdditionsNum += ignoreNum
       continue
     }
     if (change.removed) {
-      const ignoreLines = ignoreCount(change.value.trim().split('\n'))
-      deletionsNum += count(change.value.trim(), '\n') + 1 - ignoreLines
-      ignoreNum.deletions += ignoreLines
+      const ignoreNum = ignoreCount(change.value.trim().split('\n'))
+      deletionsNum += count(change.value.trim(), '\n') + 1 - ignoreNum
+      ignoreDeletionsNum += ignoreNum
       continue
     }
   }
-  return { additionsNum, deletionsNum, ignoreNum }
+  return {
+    additionsNum,
+    deletionsNum,
+    ignoreAdditionsNum,
+    ignoreDeletionsNum,
+  }
 }
 
 export function createSplitDiff(

--- a/vue2-playground/App.vue
+++ b/vue2-playground/App.vue
@@ -2,10 +2,11 @@
 import { reactive, version } from 'vue-demi'
 
 const form = reactive({
-  oldString: '<script setup lang="ts">',
-  newString: '<script lang="ts" setup>',
-  language: 'python',
+  oldString: '{\n  "code": "200",\n  "msg": "请求成功",\n  "data": {\n    "hitokoto": "往者不可谏，来者犹可追。",\n    "from": "论语·微子篇"\n  },\n  "time": "2024-01-12 17:27:03"\n}',
+  newString: '{\n  "code": "200",\n  "msg": "请求成功",\n  "data": {\n    "hitokoto": "成熟的人眼里满是前途，稚嫩的人眼里满是爱恨情仇。",\n    "from": "网易云热评"\n  },\n  "time": "2024-01-12 17:27:06"\n}',
+  language: 'json',
   diffStyle: 'word',
+  ignoreMatchingLines: 'time',
 })
 </script>
 
@@ -21,6 +22,7 @@ const form = reactive({
       :new-string="form.newString"
       :language="form.language"
       :diff-style="form.diffStyle"
+      :ignore-matching-lines="form.ignoreMatchingLines"
       output-format="side-by-side"
     />
   </div>

--- a/vue2.7-playground/App.vue
+++ b/vue2.7-playground/App.vue
@@ -3,10 +3,11 @@ import { version } from 'vue-demi'
 import { reactive } from 'vue'
 
 const form = reactive({
-  oldString: '<script setup lang="ts">',
-  newString: '<script lang="ts" setup>',
-  language: 'python',
+  oldString: '{\n  "code": "200",\n  "msg": "请求成功",\n  "data": {\n    "hitokoto": "往者不可谏，来者犹可追。",\n    "from": "论语·微子篇"\n  },\n  "time": "2024-01-12 17:27:03"\n}',
+  newString: '{\n  "code": "200",\n  "msg": "请求成功",\n  "data": {\n    "hitokoto": "成熟的人眼里满是前途，稚嫩的人眼里满是爱恨情仇。",\n    "from": "网易云热评"\n  },\n  "time": "2024-01-12 17:27:06"\n}',
+  language: 'json',
   diffStyle: 'word',
+  ignoreMatchingLines: 'time',
 })
 </script>
 
@@ -22,6 +23,7 @@ const form = reactive({
       :new-string="form.newString"
       :language="form.language"
       :diff-style="form.diffStyle"
+      :ignore-matching-lines="form.ignoreMatchingLines"
       output-format="side-by-side"
     />
   </div>

--- a/vue3-playground/App.vue
+++ b/vue3-playground/App.vue
@@ -8,13 +8,14 @@ import { reactive } from 'vue'
 const form = reactive({
   // oldString: oldLongText,
   // newString: newLongText,
-  oldString: '123\n123\n123\n456\n123\n123\n123\n123\n123\n123\n123\n',
-  newString: '123\n123\n123\n123\n123\n123\n123\n123\n123\n123\n123\n',
+  oldString: '{\n  "code": "200",\n  "msg": "请求成功",\n  "data": {\n    "hitokoto": "往者不可谏，来者犹可追。",\n    "from": "论语·微子篇"\n  },\n  "time": "2024-01-12 17:27:03"\n}',
+  newString: '{\n  "code": "200",\n  "msg": "请求成功",\n  "data": {\n    "hitokoto": "成熟的人眼里满是前途，稚嫩的人眼里满是爱恨情仇。",\n    "from": "网易云热评"\n  },\n  "time": "2024-01-12 17:27:06"\n}',
   filename: 'oldFile',
   newFilename: 'newFile',
-  language: 'plaintext',
+  language: 'json',
   diffStyle: 'word',
-  outputFormat: 'line-by-line',
+  outputFormat: 'site-by-site',
+  ignoreMatchingLines: 'time',
   context: 3,
 })
 </script>
@@ -34,6 +35,7 @@ const form = reactive({
     :new-filename="form.newFilename"
     :language="form.language"
     :output-format="form.outputFormat"
+    :ignore-matching-lines="form.ignoreMatchingLines"
     :diff-style="form.diffStyle"
     :context="form.context"
   />


### PR DESCRIPTION
## Description

灵感来自命令 ` diff file1.json file2.json --ignore-matching-lines="time"`，
增加行关键词忽略匹配功能，~~仅 `side-by-side` 模式生效~~。

Resolved #120

## Preview

设置 `ignoreMatchingLines="time"`，效果如下：

<img width="1439" alt="image" src="https://github.com/Shimada666/v-code-diff/assets/33419593/ec332e14-e555-4695-92d0-44c7363e6580">
